### PR TITLE
(NOT important) Modify customer email error messages

### DIFF
--- a/RepairShop-Backend/src/main/java/ca/mcgill/ecse321/repairshop/controller/ReminderController.java
+++ b/RepairShop-Backend/src/main/java/ca/mcgill/ecse321/repairshop/controller/ReminderController.java
@@ -1,16 +1,10 @@
 package ca.mcgill.ecse321.repairshop.controller;
 
-import ca.mcgill.ecse321.repairshop.model.Customer;
-import ca.mcgill.ecse321.repairshop.model.ReminderType;
-import ca.mcgill.ecse321.repairshop.repository.CustomerRepository;
-import ca.mcgill.ecse321.repairshop.service.CustomerService;
 import ca.mcgill.ecse321.repairshop.service.ReminderService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
-
-import java.sql.Timestamp;
 
 @CrossOrigin("*")
 @RestController
@@ -27,7 +21,7 @@ public class ReminderController {
     @GetMapping("/customer")
     public ResponseEntity<?> getCustomerReminders(@RequestParam String email) {
         try {
-            return new ResponseEntity<>(reminderService.getRemindersByCustomer(email), HttpStatus.OK);
+            return new ResponseEntity<>(reminderService.getRemindersByCustomerEmail(email), HttpStatus.OK);
         } catch (Exception e) {
             return new ResponseEntity<>(HttpStatus.NOT_FOUND);
         }

--- a/RepairShop-Backend/src/main/java/ca/mcgill/ecse321/repairshop/service/ReminderService.java
+++ b/RepairShop-Backend/src/main/java/ca/mcgill/ecse321/repairshop/service/ReminderService.java
@@ -30,10 +30,10 @@ public class ReminderService {
      * @return a list of reminderDtos
      */
     @Transactional
-    public List<ReminderDto> getRemindersByCustomer(String email) throws Exception {
+    public List<ReminderDto> getRemindersByCustomerEmail(String email) throws Exception {
 
         Customer customer = customerRepository.findCustomerByEmail(email);
-        if (customer == null) throw new Exception("A valid customer is required");
+        if (customer == null) throw new Exception("A valid customer email is required");
 
         List<Reminder> reminders;
         reminders = reminderRepository.findByCustomer(customer);
@@ -54,7 +54,7 @@ public class ReminderService {
 
         if (dateTime == null || dateTime.equals("")) throw new Exception("The Timestamp is mandatory");
         if (type == null || type.equals("")) throw new Exception("The ReminderType is mandatory");
-        if (email == null || email.equals("")) throw new Exception("The Customer is mandatory");
+        if (email == null || email.equals("")) throw new Exception("The customer email is mandatory");
 
         Timestamp timestamp = null;
         ReminderType reminderType = null;
@@ -75,7 +75,7 @@ public class ReminderService {
         try {
             customer = customerRepository.findCustomerByEmail(email);
         } catch (Exception e) {
-            throw new Exception("The provided Customer does not exist");
+            throw new Exception("The provided customer email does not exist");
         }
 
         Reminder reminder = new Reminder();

--- a/RepairShop-Backend/src/test/java/ca/mcgill/ecse321/repairshop/service/TestReminderService.java
+++ b/RepairShop-Backend/src/test/java/ca/mcgill/ecse321/repairshop/service/TestReminderService.java
@@ -84,7 +84,7 @@ public class TestReminderService {
 
                 return customer;
 
-            } else throw new Exception("The provided Customer does not exist");
+            } else throw new Exception("The provided customer email does not exist");
 
         });
 
@@ -178,7 +178,7 @@ public class TestReminderService {
         try {
             reminderDto = reminderService.createReminder(REMINDER_TIMESTAMP.toString(), REMINDER_TYPE.toString(), null);
         } catch (Exception e) {
-            assertEquals("The Customer is mandatory", e.getMessage());
+            assertEquals("The customer email is mandatory", e.getMessage());
         }
 
         assertNull(reminderDto);
@@ -193,7 +193,7 @@ public class TestReminderService {
         try {
             reminderDto = reminderService.createReminder(REMINDER_TIMESTAMP.toString(), REMINDER_TYPE.toString(), "notACustomerEmail");
         } catch (Exception e) {
-            assertEquals("The provided Customer does not exist", e.getMessage());
+            assertEquals("The provided customer email does not exist", e.getMessage());
         }
 
         assertNull(reminderDto);
@@ -206,7 +206,7 @@ public class TestReminderService {
         List<ReminderDto> reminderDtos = null;
 
         try {
-            reminderDtos = reminderService.getRemindersByCustomer(CUSTOMER_EMAIL);
+            reminderDtos = reminderService.getRemindersByCustomerEmail(CUSTOMER_EMAIL);
         } catch (Exception e) {
             fail(e.getMessage());
         }
@@ -228,9 +228,9 @@ public class TestReminderService {
         List<ReminderDto> reminderDtos = null;
 
         try {
-            reminderDtos = reminderService.getRemindersByCustomer(null);
+            reminderDtos = reminderService.getRemindersByCustomerEmail(null);
         } catch (Exception e) {
-            assertEquals("A valid customer is required", e.getMessage());
+            assertEquals("A valid customer email is required", e.getMessage());
         }
 
         assertNull(reminderDtos);
@@ -243,9 +243,9 @@ public class TestReminderService {
         List<ReminderDto> reminderDtos = null;
 
         try {
-            reminderDtos = reminderService.getRemindersByCustomer("notACustomerEmail");
+            reminderDtos = reminderService.getRemindersByCustomerEmail("notACustomerEmail");
         } catch (Exception e) {
-            assertEquals("The provided Customer does not exist", e.getMessage());
+            assertEquals("The provided customer email does not exist", e.getMessage());
         }
 
         assertNull(reminderDtos);


### PR DESCRIPTION
- Changed some error messages related to customer email. Instead of "Customer" -> "customer email"
- Change name of a method `getRemindersByCustomer` -> `getRemindersByCustomerEmail`

